### PR TITLE
do not modify smashed input, i.e. do not munch empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ function readStream(file) {
 
   fs.readFile(file, "utf8", function(error, text) {
     if (error) return void emitter.emit("error", error);
-    text.split("\n").some(function(line, i) {
+    text.replace(/[\n]$/g, "").split("\n").some(function(line, i) {
       if (/^import\b/.test(line)) {
         var match = /^import\s+"([^"]+)"\s*;?\s*(?:\/\/.*)?$/.exec(line);
         if (match) {
@@ -170,7 +170,7 @@ function readStream(file) {
           emitter.emit("error", new Error("invalid import: " + file + ":" + i + ": " + line));
           return true;
         }
-      } else if (line) {
+      } else {
         emitter.emit("data", line + "\n"); // TODO combine lines?
       }
     }) || emitter.emit("end");


### PR DESCRIPTION
pass along empty lines when smashing the input files: this ensures that input is not altered during the smash process (except of course the expansion of the import() statements)

(passed all tests: npm test)

Note: I did this as I like the d3.js output much better when it has the exact same whitespace  as the original files - this assists readability of the smashed produce, while it does not impact the minification process for those who want a minified variant.
