### PR TITLE
Add "engineStrict": true

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "engineStrict": true,
   "dependencies": {
     "optimist": "0.3.x",
     "queue-async": "1.0.x"


### PR DESCRIPTION
A.k.a. the ["I really mean it"](https://npmjs.org/doc/json.html#engineStrict) property.

On 0.8.x, smash fails with `TypeError: undefined is not a function`.
