### PR TITLE
Allow in-line commentted imports (optional)

### DIFF
--- a/lib/smash/emit-imports.js
+++ b/lib/smash/emit-imports.js
@@ -23,7 +23,7 @@ module.exports = function(file) {
   function line(line, number) {
     if (/^import\b/.test(line)) {
       flush();
-      var match = /^import\s+"([^"]+)"\s*;?\s*(?:\/\/.*)?$/.exec(line);
+      var match = /^(?:\/\/\s*)?import\s+"([^"]+)"\s*;?\s*(?:\/\/.*)?$/.exec(line);
       if (match) {
         emitter.emit("import", path.join(directory, expandFile(match[1], extension)));
       } else {


### PR DESCRIPTION
(a) Source file lints better  
(b) Source file can be used standalone (provided any required dependencies are loaded manually)

This is not strictly backwards compatible, as any previous source code with commented imports (meant not to execute) will execute under this commit.
