### PR TITLE
Allow single quotes to be used for imports:

### DIFF
--- a/lib/smash/emit-imports.js
+++ b/lib/smash/emit-imports.js
@@ -23,9 +23,9 @@ module.exports = function(file) {
   function line(line, number) {
     if (/^import\b/.test(line)) {
       flush();
-      var match = /^import\s+"([^"]+)"\s*;?\s*(?:\/\/.*)?$/.exec(line);
+      var match = /^import\s+(['"])([^\1]+)\1\s*;?\s*(?:\/\/.*)?$/.exec(line);
       if (match) {
-        emitter.emit("import", path.join(directory, expandFile(match[1], extension)));
+        emitter.emit("import", path.join(directory, expandFile(match[2], extension)));
       } else {
         lineEmitter.removeAllListeners(); // ignore subsequent lines
         error(new Error("invalid import: " + file + ":" + number + ": " + line));

--- a/test/data/import-single-quote-expected.js
+++ b/test/data/import-single-quote-expected.js
@@ -1,0 +1,3 @@
+var foo;
+var bar;
+var bar;

--- a/test/data/import-single-quote.js
+++ b/test/data/import-single-quote.js
@@ -1,0 +1,3 @@
+import 'foo'; 
+import 'bar'// And so is this.
+var bar;

--- a/test/smash-test.js
+++ b/test/smash-test.js
@@ -11,6 +11,7 @@ suite.addBatch({
     "on a file with no imports": testCase(["test/data/foo.js"], "test/data/foo.js"),
     "on a file with imports with trailing comments": testCase(["test/data/trailing-comment-import.js"], "test/data/trailing-comment-import-expected.js"),
     "on a file with invalid import syntax": testFailureCase(["test/data/invalid-import-syntax.js"], "invalid import: test/data/invalid-import-syntax.js:0: import foo;"),
+    "on a file with import syntax using single quote": testCase(["test/data/import-single-quote.js"], "test/data/import-single-quote-expected.js" ),
     "on a file with that imports a file that does not exist": testFailureCase(["test/data/imports-not-found.js"], "ENOENT, open 'test/data/not-found.js'"),
     "on a file with a commented-out import": testCase(["test/data/commented-import.js"], "test/data/commented-import.js"),
     "on a file with a not-commented-out import": testCase(["test/data/not-commented-import.js"], "test/data/not-commented-import-expected.js"),


### PR DESCRIPTION
First off, Thank you for this great library and the others you've written. I was using this library on one of my projects and found it inconvenient that i couldn't use single-quotes with import syntax.

I wanted to be able to say:

import 'foo'

This PR adds support for that, i've copied and modified some existing tests to cover this.

Thanks.
