### PR TITLE
Adding link to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SMASH
 
-SMASH TOGETHER FILES! PROBABLY JAVASCRIPT.
+SMASH TOGETHER FILES! PROBABLY JAVASCRIPT. Documentation in [the wiki](https://github.com/mbostock/smash/wiki)
 
 SAY THIS foo.js:
 


### PR DESCRIPTION
Most modules don't have wikis, so most people won't look there unless they're told to