### PR TITLE
vm.runInNewContext chokes if sandbox is null

### DIFF
--- a/lib/smash/load.js
+++ b/lib/smash/load.js
@@ -4,7 +4,7 @@ var vm = require("vm"),
 // Loads the specified files and their imports, then evaluates the specified
 // expression in the context of the concatenated code.
 module.exports = function(files, expression, sandbox, callback) {
-  if (arguments.length < 4) callback = sandbox, sandbox = null;
+  if (arguments.length < 4) callback = sandbox, sandbox = undefined;
   var chunks = [];
   smash(files)
       .on("error", callback)


### PR DESCRIPTION
Simply setting it to undefined is fine, though - and should be backward-compatible.
Fixes #25 
