### PR TITLE
ignore-missing: compare error.code to 'ENOENT'

### DIFF
--- a/lib/smash/read-all-imports.js
+++ b/lib/smash/read-all-imports.js
@@ -16,7 +16,7 @@ module.exports = function(files, options, callback) {
     fileMap[file] = true;
     readImports(file, function(error, files) {
       if (error) {
-        if (options["ignore-missing"] && error.errno === 34) files = [];
+        if (options["ignore-missing"] && error.code === 'ENOENT') files = [];
         else return void callback(error);
       }
       var q = queue(1);


### PR DESCRIPTION
errno comparison is less reliable, patch 2/2
