### PR TITLE
Right error but message depends on node version

### DIFF
--- a/test/readGraph-test.js
+++ b/test/readGraph-test.js
@@ -47,7 +47,8 @@ suite.addBatch({
         });
       },
       "throws an error with the expected message": function(error) {
-        assert.deepEqual(error.message, "ENOENT, open 'test/data/not-found.js'");
+        assert.equal(error.code, "ENOENT");
+        assert.equal(error.path, 'test/data/not-found.js');
       }
     },
     "on a file with that imports a file that does not exist with --ignore-missing": {


### PR DESCRIPTION
Before:
ENOENT, open 'test/data/not-found.js'
After:
ENOENT: no such file or directory, open 'test/data/not-found.js'
