### PR TITLE
Right error but message depends on node version

### DIFF
--- a/test/smash-test.js
+++ b/test/smash-test.js
@@ -13,7 +13,7 @@ suite.addBatch({
     "on a file with single-quote import syntax": testCase(["test/data/single-quote-import.js"], "test/data/single-quote-import-expected.js"),
     "on a file with mismatched quote delimiters": testFailureCase(["test/data/mismatched-quotes.js"], "invalid import: test/data/mismatched-quotes.js:0: import 'foo\";"),
     "on a file with invalid import syntax": testFailureCase(["test/data/invalid-import-syntax.js"], "invalid import: test/data/invalid-import-syntax.js:0: import foo;"),
-    "on a file with that imports a file that does not exist": testFailureCase(["test/data/imports-not-found.js"], "ENOENT, open 'test/data/not-found.js'"),
+    "on a file with that imports a file that does not exist": testFailureCase(["test/data/imports-not-found.js"], "ENOENT: no such file or directory, open 'test/data/not-found.js'"),
     "on a file with a commented-out import": testCase(["test/data/commented-import.js"], "test/data/commented-import.js"),
     "on a file with a not-commented-out import": testCase(["test/data/not-commented-import.js"], "test/data/not-commented-import-expected.js"),
     "on a file with one import": testCase(["test/data/imports-foo.js"], "test/data/imports-foo-expected.js"),


### PR DESCRIPTION
Before:
ENOENT, open 'test/data/not-found.js'
After:
ENOENT: no such file or directory, open 'test/data/not-found.js'

This fix won't be backward-compatible
